### PR TITLE
[_]: fix/init-db-script-writing-in-admindb

### DIFF
--- a/src/database/mongo/scripts/init.ts
+++ b/src/database/mongo/scripts/init.ts
@@ -43,7 +43,7 @@ async function init() {
 
     const fixtures = new Fixtures({ dir: './src/database/mongo/fixtures' });
 
-    await fixtures.connect(uri);
+    await fixtures.connect(uri, {}, process.env.DATABASE_NAME);
     await fixtures.unload();
     await fixtures.load();
     await fixtures.disconnect();


### PR DESCRIPTION
- Prevents fixtures script to write in 'admin' database.
- Forces fixtures script to write in 'photos' database.