### PR TITLE
hotfix/bind-fastify-to-all-interfaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ async function start(config: ServerConfig): Promise<StopManager> {
   fastify.register(photosRouter.handler, { prefix: photosRouter.prefix });
   fastify.log.info('Connected to database');
 
-  await fastify.listen(config.port || 8000);
+  await fastify.listen(config.port || 8000, '0.0.0.0');
 
   return generateStopHandler(fastify, database);
 }


### PR DESCRIPTION
- Binds Fastify to all interfaces as by default it's bound to 127.0.0.1 what makes the HTTP server not reachable via Docker/Kubernetes.