### PR TITLE
[_]: Patch wrongly created photo hash during photo create

### DIFF
--- a/__tests__/api/photos/repository.test.ts
+++ b/__tests__/api/photos/repository.test.ts
@@ -72,6 +72,24 @@ describe('Photos repository methods', () => {
     expect(received).toStrictEqual(expected);
   });
 
+  it('getOne()', async () => {
+    const alreadyExistentPhoto = existingPhoto;
+    const expected = { 
+      ...alreadyExistentPhoto, 
+      id: alreadyExistentPhoto._id.toString(),
+      deviceId: alreadyExistentPhoto.deviceId.toString(),
+      userId: alreadyExistentPhoto.userId.toString()
+    };
+
+    const photo = await repository.getOne({ name: alreadyExistentPhoto.name });
+
+    expect(photo).not.toBeNull();
+
+    const received = { ...photo, _id: alreadyExistentPhoto._id }; 
+
+    expect(received).toStrictEqual(expected);
+  });
+
   it('create()', async () => {
     const alreadyExistentPhoto = { ...photos[0] };
     const received = await repository.create({

--- a/__tests__/api/photos/usecase.test.ts
+++ b/__tests__/api/photos/usecase.test.ts
@@ -67,6 +67,28 @@ describe('Photos usecases', () => {
       expect(received).toStrictEqual(expected);
     });
 
+    it('When a photo is going to be saved, should update the hash if the photo already exists', async () => {
+      const existingPhoto: Photo = {...photoThatExists, hash: 'incorrect-hash'};
+
+      stub(photosRepository, 'getOne').resolves(existingPhoto);
+      stub(photosRepository, 'updateById').resolves();
+
+      const received = await usecase.savePhoto({...photoThatExists, hash: 'correct-hash'});
+
+      expect(received).toStrictEqual({ ...existingPhoto, hash: 'correct-hash' });
+    });
+
+    it('When a photo is going to be saved, should create it if the photo does not exists', async () => {
+      const newPhoto: Photo = photoThatExists;
+
+      stub(photosRepository, 'getOne').resolves(null);
+      stub(photosRepository, 'create').resolves(newPhoto);
+      
+      const received = await usecase.savePhoto(photoThatExists);
+
+      expect(received).toStrictEqual(newPhoto);
+    });
+
     it('When a photo is deleted, should be marked as already existent', async () => {
       const deletedPhoto: Photo = { ...photoThatExists, status: PhotoStatus.Deleted };
 

--- a/src/api/photos/repository.ts
+++ b/src/api/photos/repository.ts
@@ -84,6 +84,22 @@ export class PhotosRepository implements Repository<Photo> {
       });
   }
 
+  getOne({name, takenAt}: Partial<Photo>) {
+    const filter: Filter<PhotoDocument> = {};
+    name ? (filter.name = name) : null;
+    takenAt ? (filter.takenAt = takenAt) : null;
+    
+    return this.collection.findOne<PhotoDocument>(filter).then((doc): Photo | null => {
+      if (!doc || !doc._id) {
+        return null;
+      }
+
+      return mongoDocToModel(doc);
+    });
+  }
+
+
+
   async getUsage(userId: string): Promise<number> {
     const result: { _id: null; usage: number } | null = await this.collection
       .aggregate<{ _id: null; usage: number }>([

--- a/src/api/photos/usecase.ts
+++ b/src/api/photos/usecase.ts
@@ -110,10 +110,15 @@ export class PhotosUsecase {
     const existingPhoto = await this.photosRepository.getOne({name: data.name, takenAt: data.takenAt});
 
     if(!existingPhoto) {
-      return this.photosRepository.create(photoToCreate);
       
+      return this.photosRepository.create(photoToCreate);
     } else {
-      this.photosRepository.updateById(existingPhoto.id, {
+
+      if(existingPhoto.hash === photoToCreate.hash) {
+        throw new UsecaseError('A photo with this characteristics already exists');
+      }
+
+      await this.photosRepository.updateById(existingPhoto.id, {
         hash: data.hash
       });
 

--- a/src/api/photos/usecase.ts
+++ b/src/api/photos/usecase.ts
@@ -84,7 +84,7 @@ export class PhotosUsecase {
     return usage;
   }
 
-  savePhoto(data: NewPhoto): Promise<Photo> {
+  async savePhoto(data: NewPhoto): Promise<Photo> {
     const now = new Date();
     const photoToCreate: Omit<Photo, 'id'> = {
       ...data,
@@ -92,7 +92,36 @@ export class PhotosUsecase {
       statusChangedAt: now
     };
 
-    return this.photosRepository.create(photoToCreate);
+    /**
+     * PATCH PHOTO HASH
+     * 
+     * In Drive-mobile the photo hash was malformed, since the
+     * hash was created using a malformed value, now that is fixed
+     * we need to patch the hash of those photos that match
+     * in name and date with the photo that wants to be saved so we
+     * avoid duplicated photos.
+     * 
+     * If the incoming photo matches in name and date with an already
+     * existing photo, we don't create the photo, we just update the hash
+     * of the one that already exists because it means that the photo
+     * was already uploaded, but the hash was wrong.
+     */
+      
+    const existingPhoto = await this.photosRepository.getOne({name: data.name, takenAt: data.takenAt});
+
+    if(!existingPhoto) {
+      return this.photosRepository.create(photoToCreate);
+      
+    } else {
+      this.photosRepository.updateById(existingPhoto.id, {
+        hash: data.hash
+      });
+
+      return {
+        ...existingPhoto,
+        hash: data.hash
+      };
+    }    
   }
 
   async deletePhoto(photoId: string) {


### PR DESCRIPTION
Since some drive-mobile photos were being created with a wrong hash, now that is fixed we need a mechanism to identify those photos with wrong hashes and patch them.

Now every time we want to create a photo, we first look for a photo with the same name and takenAt values, if we found a photo with those matches, and the hashes are different, we update the existing photo