### PR TITLE
[_]:(feature) New endpoint, find an existing photo, or create one

### DIFF
--- a/src/api/photos/controller.ts
+++ b/src/api/photos/controller.ts
@@ -98,6 +98,17 @@ export class PhotosController {
     rep.send({ usage });
   }
 
+  async findOrCreatePhoto(req: FastifyRequest<{ Body: CreatePhotoType }>, rep: FastifyReply) {
+    const user = req.user as AuthorizedUser;
+    const [checkedPhoto] = await this.photosUsecase.photosWithTheseCharacteristicsExist(user.payload.uuid, [req.body]);
+
+    if (checkedPhoto.exists) {
+      return rep.code(200).send(checkedPhoto);
+    } else {
+      return this.postPhoto(req, rep);
+    }
+  }
+
   async postPhoto(req: FastifyRequest<{ Body: CreatePhotoType }>, rep: FastifyReply) {
     const user = req.user as AuthorizedUser;
     const body: NewPhoto = req.body;

--- a/src/api/photos/index.ts
+++ b/src/api/photos/index.ts
@@ -38,7 +38,7 @@ export const buildRouter = (controller: PhotosController): FastifyRouter => {
         controller.postPhoto.bind(controller),
       );
       server.post<{ Body: CreatePhotoType }>(
-        '/maybe-existing-photo',
+        '/photo/exists',
         {
           preValidation: server.authenticate,
           schema: {

--- a/src/api/photos/index.ts
+++ b/src/api/photos/index.ts
@@ -37,6 +37,16 @@ export const buildRouter = (controller: PhotosController): FastifyRouter => {
         },
         controller.postPhoto.bind(controller),
       );
+      server.post<{ Body: CreatePhotoType }>(
+        '/maybe-existing-photo',
+        {
+          preValidation: server.authenticate,
+          schema: {
+            body: CreatePhotoSchema,
+          },
+        },
+        controller.findOrCreatePhoto.bind(controller),
+      );
       server.patch('/:id', { preValidation: server.authenticate }, controller.updatePhotoById.bind(controller));
       server.delete('/:id', { preValidation: server.authenticate }, controller.deletePhotoById.bind(controller));
 


### PR DESCRIPTION
Since typically the sync process for a photo involves two steps (check if the photo exists, and then create the photo via http) this PR aims to wrap both operations in a single one.

With this we can minimize the server trips and the network usage which in some products such mobile, drains the battery a lot.

