### PR TITLE
[MT-46]: fix/enforce-bucket-check

### DIFF
--- a/__tests__/api/photos/usecase.test.ts
+++ b/__tests__/api/photos/usecase.test.ts
@@ -37,7 +37,7 @@ const photoThatExists: Photo = {
   statusChangedAt: new Date(),
   takenAt: new Date(),
   type: 'jpg',
-  userId: 'user-id',
+  userId: user.id,
   width: 500,
   itemType: PhotosItemType.PHOTO,
   previews: []
@@ -74,7 +74,11 @@ describe('Photos usecases', () => {
       stub(photosRepository, 'getOne').resolves(existingPhoto);
       stub(photosRepository, 'updateById').resolves();
 
-      const received = await usecase.savePhoto({...photoThatExists, hash: 'correct-hash'});
+      const received = await usecase.savePhoto({
+        ...photoThatExists, 
+        hash: 'correct-hash', 
+        networkBucketId: user.bucketId 
+      });
 
       expect(received).toStrictEqual({ ...existingPhoto, hash: 'correct-hash' });
     });
@@ -84,8 +88,9 @@ describe('Photos usecases', () => {
 
       stub(photosRepository, 'getOne').resolves(null);
       stub(photosRepository, 'create').resolves(newPhoto);
+      stub(usersRepository, 'getByBucket').resolves(user);
       
-      const received = await usecase.savePhoto(photoThatExists);
+      const received = await usecase.savePhoto({ ...photoThatExists, networkBucketId: user.bucketId });
 
       expect(received).toStrictEqual(newPhoto);
     });

--- a/src/api/photos/schemas.ts
+++ b/src/api/photos/schemas.ts
@@ -25,6 +25,7 @@ export const CreatePhotoSchema = Type.Object({
   hash: Type.String(),
   itemType: Type.Enum(PhotosItemType),
   duration: Type.Optional(Type.Number()),
+  networkBucketId: Type.String(),
 });
 
 export const UpdatePhotoSchema = Type.Object({
@@ -44,11 +45,11 @@ export const GetPhotosQueryParamsSchema = Type.Object({
 const PhotoExistsSchema = Type.Object({
   hash: Type.String(),
   takenAt: Type.Any(),
-  name: Type.String()
+  name: Type.String(),
 });
 
 export const CheckPhotosExistenceSchema = Type.Object({
-  photos: Type.Array(PhotoExistsSchema)
+  photos: Type.Array(PhotoExistsSchema),
 });
 
 export type CreatePhotoType = Static<typeof CreatePhotoSchema>;

--- a/src/api/photos/usecase.ts
+++ b/src/api/photos/usecase.ts
@@ -15,6 +15,12 @@ export class PhotoNotFoundError extends UsecaseError {
   }
 }
 
+export class WrongBucketIdError extends UsecaseError {
+  constructor(bucketId: User['bucketId']) {
+    super('Bucket' + (bucketId  ? ` ${bucketId}` : '') + ' is wrong');
+  }
+}
+
 export class PhotosUsecase {
   private photosRepository: PhotosRepository;
   private usersRepository: UsersRepository;
@@ -117,7 +123,7 @@ export class PhotosUsecase {
       const user = await this.usersRepository.getByBucket(data.networkBucketId);
       
       if (!user) {
-        throw new UsecaseError('User not found by network bucket id');
+        throw new WrongBucketIdError(data.networkBucketId);
       }
       
       return this.photosRepository.create(photoToCreate);

--- a/src/api/photos/usecase.ts
+++ b/src/api/photos/usecase.ts
@@ -114,6 +114,11 @@ export class PhotosUsecase {
     });
 
     if(!existingPhoto) {
+      const user = await this.usersRepository.getByBucket(data.networkBucketId);
+      
+      if (!user) {
+        throw new UsecaseError('User not found by network bucket id');
+      }
       
       return this.photosRepository.create(photoToCreate);
     } else {

--- a/src/api/users/repository.ts
+++ b/src/api/users/repository.ts
@@ -44,6 +44,17 @@ export class UsersRepository implements Repository<User> {
         return mongoDocToModel(doc);
       });
   }
+  
+  getByBucket(bucketId: User['bucketId']): Promise<User | null> {
+    return this.collection.findOne({ bucketId })
+      .then((doc: UserDocument | null) => {
+        if (!doc || !doc._id) {
+          return null;
+        }
+
+        return mongoDocToModel(doc);
+      });
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   get(where: Filter<UserDocument>) {

--- a/src/models/Photo.ts
+++ b/src/models/Photo.ts
@@ -8,30 +8,30 @@ export type PhotoId = string;
 export enum PhotoStatus {
   Exists = 'EXISTS',
   Trashed = 'TRASHED',
-  Deleted = 'DELETED'
+  Deleted = 'DELETED',
 }
 
 export interface Photo {
-  id: PhotoId
-  name: string
-  type: PhotoType
-  size: number
-  width: number
-  height: number
-  fileId: FileId
-  previewId: FileId
-  previews?: { width: number; height: number; size: number; fileId: FileId; type: PhotoPreviewType }[]
-  deviceId: DeviceId
-  userId: UserId
-  status: PhotoStatus
+  id: PhotoId;
+  name: string;
+  type: PhotoType;
+  size: number;
+  width: number;
+  height: number;
+  fileId: FileId;
+  previewId: FileId;
+  previews?: { width: number; height: number; size: number; fileId: FileId; type: PhotoPreviewType }[];
+  deviceId: DeviceId;
+  userId: UserId;
+  status: PhotoStatus;
   hash: string;
-  statusChangedAt: Date
-  takenAt: Date
-  duration?: number
-  itemType: PhotosItemType
+  statusChangedAt: Date;
+  takenAt: Date;
+  duration?: number;
+  itemType: PhotosItemType;
 }
 
-export type NewPhoto = Omit<Photo, 'id' | 'statusChangedAt' | 'status'>;
+export type NewPhoto = Omit<Photo, 'id' | 'statusChangedAt' | 'status'> & { networkBucketId: string };
 
 export enum PhotoPreviewType {
   PNG = 'PNG',


### PR DESCRIPTION
- Enforces the correct bucket id from the network (the one used for photos) in order to avoid any trick from any client application sending the wrong bucket id for storing a photo.