### PR TITLE
[_]:(hotfix) Convert takenAt from the photo body to UTC

### DIFF
--- a/src/api/photos/controller.ts
+++ b/src/api/photos/controller.ts
@@ -101,7 +101,14 @@ export class PhotosController {
 
   async findOrCreatePhoto(req: FastifyRequest<{ Body: CreatePhotoType }>, rep: FastifyReply) {
     const user = req.user as AuthorizedUser;
-    const [checkedPhoto] = await this.photosUsecase.photosWithTheseCharacteristicsExist(user.payload.uuid, [req.body]);
+
+    const body = req.body;
+    body.takenAt = dateToUTC(body.takenAt);
+    const [checkedPhoto] = await this.photosUsecase.photosWithTheseCharacteristicsExist(user.payload.uuid, [{
+      name: body.name,
+      takenAt: body.takenAt,
+      hash: body.hash
+    }]);
 
     if (checkedPhoto.exists) {
       return rep.code(200).send(checkedPhoto);


### PR DESCRIPTION
The takenAt body property wasn't getting converted to UTC, since we store the UTC takenAt version when the photo is created, this property was not matching causing photos to be unabled to be retrieved as already existing ones