### PR TITLE
[_]: feat/improve-get-photos-speeds

### DIFF
--- a/src/api/photos/controller.ts
+++ b/src/api/photos/controller.ts
@@ -29,22 +29,22 @@ export class PhotosController {
     rep: FastifyReply,
   ) {
     const user = req.user as AuthorizedUser;
-    const { name, status, statusChangedAt, limit, skip, deviceId, includeDownloadLinks } = req.query;
+    const { name, status, updatedAt, limit, skip, deviceId, includeDownloadLinks } = req.query;
 
     // TODO: from is the future + cast date to UTC
-    if (!dayjs(statusChangedAt).isValid()) {
+    if (!dayjs(updatedAt).isValid()) {
       rep.status(400).send({ message: 'Bad "from" date format' });
     }
 
-    const { results, count } = await this.photosUsecase.get(
+    const results = await this.photosUsecase.get(
       user.payload.uuid,
-      { name, status, statusChangedAt: statusChangedAt ? new Date(statusChangedAt) : undefined, deviceId },
+      { name, status, updatedAt: updatedAt ? new Date(updatedAt) : undefined, deviceId },
       skip,
       limit,
     );
 
     if (!includeDownloadLinks) {
-      rep.send({ results, count });
+      rep.send({ results });
     } else {
       const { user: bridgeUser, pass: bridgePass } = user.payload.networkCredentials;
       const network = new Environment({
@@ -66,7 +66,7 @@ export class PhotosController {
         previewIndex: (result && result.index) || '',
       }));
 
-      rep.send({ results: resultsWithDownloadLinks, count, bucketId: photosUser!.bucketId });
+      rep.send({ results: resultsWithDownloadLinks, bucketId: photosUser!.bucketId });
     }
   }
 

--- a/src/api/photos/repository.ts
+++ b/src/api/photos/repository.ts
@@ -161,19 +161,19 @@ export class PhotosRepository implements Repository<Photo> {
     await this.collection.deleteMany(where);
   }
 
-  private getCursor({ name, userId, status, statusChangedAt, deviceId }: Partial<Photo>) {
+  private getCursor({ name, userId, status, updatedAt, deviceId }: Partial<Photo & { updatedAt: Date } >) {
     const filter: Filter<PhotoDocument> = {};
 
     name ? (filter.name = name) : null;
     status ? (filter.status = status) : null;
     userId ? (filter.userId = toObjectId(userId)) : null;
-    statusChangedAt
-      ? (filter.statusChangedAt = {
-          $gte: statusChangedAt,
+    updatedAt
+      ? (filter.updatedAt = {
+          $gte: updatedAt,
         })
       : null;
     deviceId ? (filter.deviceId = toObjectId(deviceId)) : null;
 
-    return this.collection.find<PhotoDocument>(filter).sort({ takenAt: 'desc' });
+    return this.collection.find<PhotoDocument>(filter);
   }
 }

--- a/src/api/photos/schemas.ts
+++ b/src/api/photos/schemas.ts
@@ -35,7 +35,7 @@ export const UpdatePhotoSchema = Type.Object({
 export const GetPhotosQueryParamsSchema = Type.Object({
   name: Type.Optional(Type.String()),
   status: Type.Optional(Type.Enum(PhotoStatus)),
-  statusChangedAt: Type.Optional(Type.String()),
+  updatedAt: Type.Optional(Type.String()),
   deviceId: Type.Optional(Type.String()),
   limit: Type.Number(),
   skip: Type.Number(),

--- a/src/api/photos/usecase.ts
+++ b/src/api/photos/usecase.ts
@@ -36,20 +36,17 @@ export class PhotosUsecase {
 
   async get(
     userUuid: string,
-    filter: {name?: string, status?: PhotoStatus, statusChangedAt?: Date, deviceId?: string },
+    filter: {name?: string, status?: PhotoStatus, updatedAt?: Date, deviceId?: string },
     skip: number,
     limit: number,
-  ): Promise<{results: Photo[], count: number}> {
+  ): Promise<Photo[]> {
     const user = await this.usersRepository.getByUuid(userUuid);
 
     if (!user) {
       throw new UsecaseError(`User with uuid ${userUuid} does not exist`);
     }
     
-    const results = await this.photosRepository.get({userId: user.id, ...filter}, skip, limit);
-    const count = await this.photosRepository.count({userId: user.id, ...filter});
-
-    return { results, count };
+    return this.photosRepository.get({ userId: user.id, ...filter }, skip, limit);
   }
 
   async photosWithTheseCharacteristicsExist(


### PR DESCRIPTION
Introduced changes:

- Reduces the time to get photos by around ~70% for photos without download links. Around ~40% for photos with download links. How? Removing an unnecessary count that was being calculated.
- Replaces filtering by field `statusChangedAt` (deprecated) for `updatedAt`, which allows requesting photos only after a given date.

Note:
- Fields `updatedAt` and `userId` have been indexed.
