### PR TITLE
[_]: feat/allow-up-to-200-photos-as-get-limit

### DIFF
--- a/src/api/photos/controller.ts
+++ b/src/api/photos/controller.ts
@@ -33,7 +33,11 @@ export class PhotosController {
 
     // TODO: from is the future + cast date to UTC
     if (!dayjs(updatedAt).isValid()) {
-      rep.status(400).send({ message: 'Bad "from" date format' });
+      return rep.status(400).send({ message: 'Bad "from" date format' });
+    }
+
+    if (limit > 200) {
+      return rep.status(400).send({ message: 'Maximum allowed "limit" is 200' });
     }
 
     const results = await this.photosUsecase.get(


### PR DESCRIPTION
Limits the "limit" query param on getting photos to 200 photos per request for security and scalability reasons.