### PR TITLE
[_]:(feature) Allow sorting by query params

### DIFF
--- a/src/api/photos/controller.ts
+++ b/src/api/photos/controller.ts
@@ -35,7 +35,7 @@ export class PhotosController {
     rep: FastifyReply,
   ) {
     const user = req.user as AuthorizedUser;
-    const { status, updatedAt, limit, skip } = req.query;
+    const { status, updatedAt, limit, skip, sortBy, sortType } = req.query;
 
     // TODO: from is the future + cast date to UTC
     if (!dayjs(updatedAt).isValid()) {
@@ -46,9 +46,11 @@ export class PhotosController {
       return rep.status(400).send({ message: 'Maximum allowed "limit" is 200' });
     }
 
-    const results = await this.photosUsecase.getSortedByUpdateAt(
+    const results = await this.photosUsecase.getSorted(
       user.payload.uuid,
-      { status, updatedAt: new Date(updatedAt) },
+      { status, updatedAt: updatedAt ? new Date(updatedAt) : undefined },
+      sortBy,
+      sortType as ('ASC' | 'DESC'),
       skip,
       limit,
     );

--- a/src/api/photos/schemas.ts
+++ b/src/api/photos/schemas.ts
@@ -45,6 +45,8 @@ export const GetPhotosQueryParamsSchema = Type.Object({
 export const GetPhotosSortedQueryParamsSchema = Type.Object({
   status: Type.Optional(Type.Enum(PhotoStatus)),
   updatedAt: Type.String(),
+  sortBy: Type.String(),
+  sortType: Type.String(),
   limit: Type.Number(),
   skip: Type.Number()
 });

--- a/src/api/photos/usecase.ts
+++ b/src/api/photos/usecase.ts
@@ -60,7 +60,7 @@ export class PhotosUsecase {
     if (!user) {
       throw new UsecaseError(`User with uuid ${userUuid} does not exist`);
     }
-    return this.photosRepository.get({ userId: user.id, ...filter }, skip, limit);
+    return this.photosRepository.getSorted({ userId: user.id, ...filter }, skip, limit, 'takenAt', 'DESC');
   }
 
   async photosWithTheseCharacteristicsExist(

--- a/src/api/photos/usecase.ts
+++ b/src/api/photos/usecase.ts
@@ -34,11 +34,13 @@ export class PhotosUsecase {
     return this.photosRepository.getById(id);
   }
 
-  async getSortedByUpdateAt(
+  async getSorted(
     uuid: User['uuid'],
-    filter: { status?: PhotoStatus, updatedAt: Date },
+    filter: { status?: PhotoStatus, updatedAt?: Date },
+    sortField = 'updatedAt',
+    sortType: 'ASC' | 'DESC' = 'DESC',
     skip?: number,
-    limit?: number
+    limit?: number,
   ): Promise<Photo[]> {
     const user = await this.usersRepository.getByUuid(uuid);
 
@@ -46,8 +48,9 @@ export class PhotosUsecase {
       throw new UsecaseError(`User ${uuid} not found`);
     }
 
-    return this.photosRepository.getSorted({ userId: user.id, ...filter }, skip, limit, 'updatedAt', 'ASC');
+    return this.photosRepository.getSorted({ userId: user.id, ...filter }, skip, limit, sortField, sortType);
   }
+
 
   async get(
     userUuid: string,
@@ -60,7 +63,7 @@ export class PhotosUsecase {
     if (!user) {
       throw new UsecaseError(`User with uuid ${userUuid} does not exist`);
     }
-    return this.photosRepository.getSorted({ userId: user.id, ...filter }, skip, limit, 'takenAt', 'DESC');
+    return this.photosRepository.get({ userId: user.id, ...filter }, skip, limit);
   }
 
   async photosWithTheseCharacteristicsExist(


### PR DESCRIPTION
Allow to get photos sorted dinamically by query parameters, some examples:

Sort by takenAt in ascending order
`/photos/sorted?sortBy=takenAt&sortType=ASC`

Sort by updatedAt in descending order from a provided updatedAt date
`/photos/sorted?&updatedAt=2023-01-23T14:57:33.494Z&sortBy=updatedAt&sortType=DESC`